### PR TITLE
Vendor:remove obsolete prop

### DIFF
--- a/config/aex_props.mk
+++ b/config/aex_props.mk
@@ -28,7 +28,6 @@ PRODUCT_GENERIC_PROPERTIES += \
     ro.build.selinux=1 \
     persist.sys.dun.override=0 \
     ro.storage_manager.enabled=true \
-    ro.substratum.verified=true \
     persist.sys.recovery_update=false \
     ro.com.google.ime.theme_id=5 \
     persist.sys.disable_rescue=true


### PR DESCRIPTION
"ro.substratum.verified" prop is not been checked and used by substratum anymore so no use of having it.

Change-Id: I628bf0e588499262b14083aaf8d6febbbeecccf6